### PR TITLE
Change tag to playframework

### DIFF
--- a/activator.properties
+++ b/activator.properties
@@ -1,6 +1,6 @@
 #Activator properties file
 #Sun Jul 07 10:51:07 BST 2013
-tags=reactive,play,akka,angularjs,elasticsearch
+tags=reactive,playframework,akka,angularjs,elasticsearch
 name=realtime-search
 description=A reactive Play!, Akka and AngularJS application using Elasticsearch to demonstrate real-time log entry search
 title=Reactive Real-time Search


### PR DESCRIPTION
We want to use the Activator tag `playframework` for all Play related projects.
